### PR TITLE
Add nested issues fetching and foreign repos, move to octokit

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,16 +2,28 @@ AllCops:
   NewCops: enable
 
 Metrics/AbcSize:
-  Max: 30
+  Enabled: false
+
+Metrics/BlockLength:
+  Enabled: false
+
+Metrics/ClassLength:
+  Enabled: false
 
 Metrics/MethodLength:
-  Max: 20
-
-Layout/LineLength:
-  Max: 120
+  Enabled: false
 
 Style/Documentation:
   Enabled: false
 
-Metrics/ClassLength:
+Layout/LineLength:
+  Enabled: false
+
+Metrics/CyclomaticComplexity:
+  Enabled: false
+
+Metrics/ParameterLists:
+  Enabled: false
+
+Naming/MethodParameterName:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,9 @@
 
 source 'https://rubygems.org'
 
+gem 'clipboard'
+gem 'faraday-retry'
+gem 'nokogiri'
+gem 'octokit'
 gem 'pry-byebug'
 gem 'rubocop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,27 +1,50 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    ast (2.4.2)
-    byebug (11.1.3)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
+    ast (2.4.3)
+    byebug (12.0.0)
+    clipboard (2.0.0)
     coderay (1.1.3)
+    faraday (2.13.0)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.0)
+      net-http (>= 0.5.0)
+    faraday-retry (2.3.1)
+      faraday (~> 2.0)
     json (2.10.2)
     language_server-protocol (3.17.0.4)
     lint_roller (1.1.0)
+    logger (1.7.0)
     method_source (1.1.0)
-    parallel (1.26.3)
-    parser (3.3.7.1)
+    mini_portile2 (2.8.8)
+    net-http (0.6.0)
+      uri
+    nokogiri (1.18.8)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
+    octokit (9.2.0)
+      faraday (>= 1, < 3)
+      sawyer (~> 0.9)
+    parallel (1.27.0)
+    parser (3.3.8.0)
       ast (~> 2.4.1)
       racc
-    pry (0.14.2)
+    prism (1.4.0)
+    pry (0.15.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    pry-byebug (3.10.1)
-      byebug (~> 11.0)
-      pry (>= 0.13, < 0.15)
+    pry-byebug (3.11.0)
+      byebug (~> 12.0)
+      pry (>= 0.13, < 0.16)
+    public_suffix (6.0.1)
     racc (1.8.1)
     rainbow (3.1.1)
     regexp_parser (2.10.0)
-    rubocop (1.73.2)
+    rubocop (1.75.3)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -29,23 +52,31 @@ GEM
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 2.9.3, < 3.0)
-      rubocop-ast (>= 1.38.0, < 2.0)
+      rubocop-ast (>= 1.44.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.38.1)
-      parser (>= 3.3.1.0)
+    rubocop-ast (1.44.1)
+      parser (>= 3.3.7.2)
+      prism (~> 1.4)
     ruby-progressbar (1.13.0)
+    sawyer (0.9.2)
+      addressable (>= 2.3.5)
+      faraday (>= 0.17.3, < 3)
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
+    uri (1.0.3)
 
 PLATFORMS
-  arm64-darwin-23
-  x86_64-darwin-21
+  ruby
 
 DEPENDENCIES
+  clipboard
+  faraday-retry
+  nokogiri
+  octokit
   pry-byebug
   rubocop
 
 BUNDLED WITH
-   2.4.6
+   2.6.5

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 Run this command with a PR URL:
 
 ```sh
-ruby pr_review.rb https://github.com/evmorov/pr-review-prompt/pull/2
+bundle exec ruby pr_review.rb --help
+bundle exec ruby pr_review.rb -u https://github.com/evmorov/pr-review-prompt/pull/2
 ```
 
 Now, just paste the PR details into ChatGPT, Claude, or any LLM for review.
@@ -22,17 +23,7 @@ It then copies everything to your clipboard.
 ## Requirements
 
 - Ruby
-- [GitHub CLI (`gh`)](https://cli.github.com/) installed and logged in:
-
-```sh
-brew install gh
-gh auth login
-```
-
-## Notes
-
-- Works on macOS (`pbcopy`). Modify for other systems if needed.
-- Requires access to the repo via `gh`.
+- GITHUB_TOKEN environment variable
 
 ## License
 

--- a/pr_review.rb
+++ b/pr_review.rb
@@ -1,191 +1,211 @@
 # frozen_string_literal: true
 
-require 'open3'
-require 'json'
+require 'base64'
+require 'clipboard'
+require 'nokogiri'
+require 'octokit'
+require 'optparse'
 
-class PrReview
-  # https://github.com/evmorov/pr-review-llm/pull/123
+class Reviewer
+  DEFAULT_PROMPT = 'Your task is to review this pull request. Do you see any problems there?'
+
+  # url or owner/repo#123 or #123
+  REGEX = %r{
+    https?://github\.com/
+      (?<owner>[\w.-]+) /
+      (?<repo>[\w.-]+) /
+      (?:pull|issues) /
+      (?<number>\d+)
+    |
+    (?:
+      (?<owner>[\w.-]+) /
+      (?<repo>[\w.-]+)
+    )?
+    \#
+    (?<number>\d+)
+  }x
+
   def initialize
-    raise 'brew install gh && gh auth login' unless system('gh auth status > /dev/null')
-
-    @pr_url = ARGV.shift
-    raise 'No Github URL is provided' if @pr_url.nil? || @pr_url.empty?
-
-    @context_paths = ARGV # optional
-    @context_paths.each { |path| raise "No file was found #{path}" unless File.exist?(path) }
+    parse_options!
+    parse_url!
+    initialize_client
   end
 
-  def run
-    prompt = []
-    prompt << '<prompt>'
-
-    prompt << wrap_content('pr-url', @pr_url)
-
-    readme = request_gh("gh repo view #{repo_url}")
-    prompt << wrap_file('README.md', limit_lines(readme, 50))
-
-    prompt << details_with_comments
-    prompt << linked_issues
-    prompt << updated_files
-    prompt << context_files
-
-    diff = request_gh("gh pr diff #{@pr_url}")
-    prompt << wrap_content('pr-diff', diff)
-
-    task = 'Check the PR. Do you see any problems there?'
-    prompt << wrap_content('your-task', task)
-
-    prompt << '</prompt>'
-    IO.popen('pbcopy', 'w') { |io| io.puts(prompt) }
+  def process
+    fetch_pull_request
+    fetch_issues
+    build_xml
+    copy_result_to_clipboard
   end
 
   private
 
-  # https://github.com/evmorov/pr-review-llm
-  def repo_url
-    @repo_url ||= @pr_url.split('/pull')[0]
+  def parse_options!
+    @prompt = DEFAULT_PROMPT
+    @include_content = false
+
+    parser = OptionParser.new do |opts|
+      opts.banner = "Usage: #{File.basename($PROGRAM_NAME)} -u URL [options]"
+
+      opts.on('-u', '--url URL', 'Pull‑request URL (https://github.com/owner/repo/pull/1)') { |v| @url = v }
+      opts.on('-p', '--prompt PROMPT', 'Custom LLM prompt') { |v| @prompt = v }
+      opts.on('-a', '--all-content', 'Include full file contents') { @include_content = true }
+      opts.on('-h', '--help', 'Show help') do
+        puts opts
+        exit
+      end
+    end
+
+    parser.parse!
   end
 
-  def branch
-    @branch ||= request_gh("gh pr view #{@pr_url} --json headRefName -q .headRefName").strip
+  def parse_url!
+    abort 'Error: Pull-request URL missing. Use -u or --url.' if @url.to_s.empty?
+
+    match = @url.match(REGEX)
+    abort 'Error: Invalid URL format. See --help for usage.' unless match
+
+    @owner = match[:owner]
+    @repo = match[:repo]
+    @pr_number = match[:number].to_i
+    @full_repo = "#{@owner}/#{@repo}"
   end
 
-  # evmorov
-  def owner
-    @owner ||= repo_url.split('github.com/')[1].split('/')[0]
+  def initialize_client
+    access_token = ENV.fetch('GITHUB_TOKEN', nil)
+    abort 'Error: GITHUB_TOKEN is not set' if access_token.to_s.empty?
+
+    @client = Octokit::Client.new(access_token:, auto_paginate: true)
+  rescue Octokit::Unauthorized
+    abort 'Error: Invalid GITHUB_TOKEN'
   end
 
-  # might be evmorov, but might be someone else if it's a fork
-  def pr_owner
-    @pr_owner ||= request_gh(
-      "gh pr view --json headRepositoryOwner #{@pr_url} | jq -r '.headRepositoryOwner.login'"
-    ).strip
-  end
+  def fetch_pull_request
+    puts "Fetching PR ##{@pr_number} for #{@full_repo}"
 
-  # pr-review-llm
-  def repo
-    @repo ||= repo_url.split('github.com/')[1].split('/')[1]
-  end
-
-  # 123
-  def pr_number
-    @pr_number ||= @pr_url.split('pull/')[1].split('/')[0]
-  end
-
-  def details_with_comments
-    request = <<~REQ
-      gh pr view --json author,body,commits,comments #{@pr_url} |
-      jq '{
-        author: .author.login,
-        body: .body,
-        comments: [.comments[] | {author: .author.login, body: .body}],
-        commits: [.commits[] | {author: [.authors[0].login], messageHeadline: .messageHeadline, messageBody: .messageBody}]
-      }'
-    REQ
-    details_with_comments = request_gh(request)
-    wrap_content('pr-description-commits-and-comments', pretty_json(details_with_comments))
-  end
-
-  # Currently only works for issues within the same repository
-  # https://github.com/cli/cli/issues/8900
-  def linked_issues
-    request = <<~REQ
-      gh api graphql -F owner='#{owner}' -F repo='#{repo}' -F pr='#{pr_number}' -f query='
-      query ($owner: String!, $repo: String!, $pr: Int!) {
-        repository(owner: $owner, name: $repo) {
-          pullRequest(number: $pr) {
-            closingIssuesReferences(first: 100) {
-              nodes {
-                number
-              }
-            }
-          }
-        }
-      }' --jq '.data.repository.pullRequest.closingIssuesReferences.nodes[].number'
-    REQ
-    issue_numbers = request_gh(request)
-    issue_numbers.split("\n").map do |issue_number|
-      linked_issue(issue_number)
+    @pull_request = @client.pull_request(@full_repo, @pr_number)
+    @comments = @client.issue_comments(@full_repo, @pr_number).map(&:body)
+    @commits = @client.pull_request_commits(@full_repo, @pr_number).map { |c| c.commit.message }
+    @files = @client.pull_request_files(@full_repo, @pr_number).map do |file|
+      {
+        filename: file.filename,
+        patch: file.patch || '(no patch data)',
+        content: @include_content ? fetch_file_content(file.filename) : '(no content)'
+      }
     end
   end
 
-  def linked_issue(issue_number)
-    issue_desc = request_gh(%(
-      gh api repos/#{owner}/#{repo}/issues/#{issue_number} \
-      --jq '"Title: \\(.title)\n--\nBody:\n\n\\(.body)"'
-    ).strip)
-    issue_comments = request_gh(%(
-      gh api --paginate repos/#{owner}/#{repo}/issues/#{issue_number}/comments \
-      --jq '.[] | "\\(.user.login): \\(.body)"'
-    ).strip)
-    wrap_content("linked-issue-#{issue_number}", "#{issue_desc}\n--\nComments:\n\n#{issue_comments}")
+  def fetch_file_content(path)
+    puts "Fetching file content for #{path}"
+
+    content = @client.contents(@full_repo, path:, ref: @pull_request.head.sha)
+    Base64.decode64(content[:content])
+  rescue Octokit::NotFound
+    '(file content not found)'
   end
 
-  def updated_files
-    result = []
-    file_paths = request_gh("gh pr diff --name-only #{@pr_url}")
-    api_contents_path = "repos/#{pr_owner}/#{repo}/contents"
+  def fetch_issues
+    @issues = []
 
-    file_paths.split("\n").each do |file_path|
-      next if %w[readme.md changelog.md].include?(file_path.downcase)
+    text = [@pull_request.body, *@comments].join("\n")
+    queue = extract_refs(text, REGEX)
+    seen = Set.new
 
-      content = request_gh(%(
-        gh api #{api_contents_path}/#{file_path}?ref=#{branch} | jq -r '.content' | base64 --decode
-      ).strip)
-      next unless content
+    until queue.empty?
+      ref = queue.shift
+      key = ref[:key]
+      next if seen.include?(key)
 
-      result << wrap_file("Updated file: #{file_path}", content)
-    end
+      seen << key
 
-    result
-  end
+      issue = fetch_issue(ref)
+      next unless issue
 
-  def context_files
-    @context_paths.map do |path|
-      wrap_file("Context file: #{path}", File.read(path))
+      @issues << issue
+
+      new_text = [issue[:description], *issue[:comments]].join("\n")
+      new_refs = extract_refs(new_text, REGEX).reject { |nref| seen.include?(nref[:key]) }
+      queue.concat(new_refs)
     end
   end
 
-  def wrap_content(tag, content)
-    r = []
-    r << "<#{tag}>"
-    r << content
-    r << "</#{tag}>"
-    r << ''
+  def extract_refs(text, pattern)
+    text.to_enum(:scan, pattern).filter_map do
+      m = Regexp.last_match
+      next unless m[:number]
+
+      {
+        owner: m[:owner] || @owner,
+        repo: m[:repo] || @repo,
+        number: m[:number].to_i,
+        key: "#{m[:owner]}/#{m[:repo]}##{m[:number]}"
+      }
+    end
   end
 
-  def wrap_file(title, content)
-    r = []
-    r << '<file>'
-    r << "<title>#{title}</title>"
-    r << '<content>'
-    r << content
-    r << '</content>'
-    r << '</file>'
-    r << ''
+  def fetch_issue(ref)
+    full_repo = "#{ref[:owner]}/#{ref[:repo]}"
+    number = ref[:number]
+
+    puts "Fetching issue ##{number} for #{full_repo}"
+
+    issue = @client.issue(full_repo, number)
+    {
+      full_repo:,
+      number:,
+      title: issue.title,
+      description: issue.body,
+      comments: @client.issue_comments(full_repo, number).map(&:body)
+    }
+  rescue Octokit::NotFound
+    puts "Issue #{number} for #{full_repo} not found, skipping"
+    nil
   end
 
-  def request_gh(cmd)
-    puts cmd.delete("\n")
-    stdout, stderr, = Open3.capture3(cmd)
+  def build_xml
+    builder = Nokogiri::XML::Builder.new(encoding: 'UTF-8') do |x|
+      x.prompt do
+        x.task @prompt
 
-    unless stderr.empty?
-      puts stderr
-      return
+        x.pull_request do
+          x.number @pr_number
+          x.title @pull_request.title
+          x.description @pull_request.body
+
+          @comments.each { |c| x.comment_ c }
+          @commits.each { |m| x.commit m }
+
+          @files.each do |file|
+            x.file do
+              x.filename file[:filename]
+              x.content file[:content]
+              x.patch file[:patch]
+            end
+          end
+        end
+
+        @issues.each do |issue|
+          x.issue do
+            x.repo issue[:full_repo]
+            x.number issue[:number]
+            x.title issue[:title]
+            x.description issue[:description]
+
+            issue[:comments].each { |c| x.comment_ c }
+          end
+        end
+
+        x.task @prompt
+      end
     end
 
-    stdout
+    @xml = builder.doc.root.to_xml
   end
 
-  def limit_lines(content, n_lines)
-    lines = content.split("\n").take(n_lines)
-    lines << '...'
-    lines.join("\n")
-  end
-
-  def pretty_json(json)
-    JSON.pretty_generate(JSON.parse(json))
+  def copy_result_to_clipboard
+    Clipboard.copy(@xml)
+    puts 'XML generated and copied to clipboard.'
   end
 end
 
-PrReview.new.run
+Reviewer.new.process


### PR DESCRIPTION
- Moved from `gh` CLI to the official Octokit SDK  
- Nested‑issues fetching  
- Foreign‑repos fetching  
- CLI options parser `--help`
- Only diff is included by default, include all files with `--all-content`  
- Modify prompt with `--prompt`  
- Moved XML building to Nokogiri  
- Moved clipboard copying to the os‑indifferent gem  

Not implemented

- A safeguard to prevent excessively deep issue fetching